### PR TITLE
Add ability to open environments in new tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -136,9 +136,9 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 			currentPath = uri.path().replace(currUriEntry.path(), '');
 		}
 		uri.path(newUri.path() + currentPath);
-		console.log('updating to ' + uri.toString());
-		console.log(tabs);
-        chrome.tabs.update(tabs[0].id, {url: uri.toString()});
+		console.log('updating to', uri.toString(), tabs);
+		if(request.openInNewTab){ chrome.tabs.create({ url: uri.toString() }); }
+		else { chrome.tabs.update(tabs[0].id, {url: uri.toString()}); }
 
   });
 });

--- a/js/popup.js
+++ b/js/popup.js
@@ -16,12 +16,13 @@ app.controller('UrlsCtrl', ['$rootScope', '$scope', function($rootScope, $scope)
 		$scope.updateActive();
 		$scope.$apply();
 	});
-	
-	$scope.selectEnv = function(url) {
-		console.log("Selected env " + url);
-		chrome.runtime.sendMessage({url: url}, function(response) {
-			
-		});
+
+	$scope.selectEnv = function(url, event) {
+		console.log('selectEnv:', url, event);
+		chrome.runtime.sendMessage({
+			url: url,
+			openInNewTab: (event.altKey || event.ctrlKey || event.metaKey)
+		}, function(rsp){});
 		window.close();
 	};
 

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
 
     <h4>Switch Domain</h4>
     <div class="list-group domains">
-      <a ng-repeat="env in envs" ng-click="selectEnv(env.url)" class="list-group-item" ng-class="{active: env.active}">{{env.url}}</a>
+      <a ng-repeat="env in envs" ng-click="selectEnv(env.url, $event)" class="list-group-item" ng-class="{active: env.active}">{{env.url}}</a>
     </div>
     
     <a class="pull-right" id="settings" href="#" ng-click="loadSettings()"><span class="glyphicon glyphicon-wrench"></span> Options</a>


### PR DESCRIPTION
While clicking a domain, user can hold down `ctrl`, `alt`, or `cmd` (on OSX) to open the selected environment in a new tab.

Resolves issue #1 
