### PR TITLE
Open new tabs next to current tab

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -155,8 +155,16 @@ chrome.extension.onMessage.addListener(function(request) {
     }
     uri.path(newUri.path() + currentPath);
     console.log('updating to', uri.toString(), tabs);
-    if(request.openInNewTab){ chrome.tabs.create({ url: uri.toString() }); }
-    else { chrome.tabs.update(tabs[0].id, {url: uri.toString()}); }
+    if(request.openInNewTab) {
+      chrome.tabs.query({active: true, currentWindow:true}, function(activeTabs) {
+        chrome.tabs.create({
+          url: uri.toString(),
+          index: (activeTabs.length > 0 && activeTabs[0].index + 1) || null
+        });
+      });
+    } else {
+      chrome.tabs.update(tabs[0].id, {url: uri.toString()});
+    }
 
   });
 });


### PR DESCRIPTION
When using ctrl/alt/meta to open a different domain in a new tab, create the tab immediately after the current tab, rather than at the end of the tab list.

There are still some other differences compared to normal ctrl+click behavior, but this is just a quick fix for one of the more jarring differences (well, jarring to me at least).